### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently supported:
 ### Requirements
 
 * ARC
-* XCode 4.4 or later (auto-generation of @synthesize)
+* Xcode 4.4 or later (auto-generation of @synthesize)
 
 ### Usage
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
